### PR TITLE
chore: adjust CI and lint recommandations

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,8 +2,6 @@ name: Lint Codebase
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ supports both SHA-1 and SHA-256 HMAC signatures for securing webhook requests.
 
 ## Inputs
 
-| Input                 | Description                                              | Default   |
-| --------------------- | -------------------------------------------------------- | --------- |
-| `production_branch`\* | Your production branch.                                  | `main`    |
-| `release_branch`      | Your release branch.                                     | `release` |
-| `webhook_production`  | The webhook URL for the production environment.          | N/A       |
-| `webhook_release`     | The webhook URL for the release environment.             | N/A       |
-| `silent`              | Whether to suppress the output of the action.            | N/A       |
-| `verbose`             | Whether to enable verbose logging of the action's steps. | N/A       |
+| Input                 | Description                            | Default   |
+|-----------------------|----------------------------------------|-----------|
+| `production_branch`\* | Your production branch.                | `main`    |
+| `release_branch`      | Your release branch.                   | `release` |
+| `webhook_production`  | Webhook URL for the production.        | N/A       |
+| `webhook_release`     | Webhook URL for the release.           | N/A       |
+| `silent`              | Suppress the output of the action.     | N/A       |
+| `verbose`             | Verbose logging of the action's steps. | N/A       |
 
 ### Note for release_branch
 
@@ -73,20 +73,16 @@ jobs:
    release_branch. If the branch is the release branch and a release webhook URL
    is provided, it sends the webhook to the release endpoint. Otherwise, it uses
    the production webhook URL. Payload:
-
-2. The webhook payload contains information about the event (event), repository,
+1. The webhook payload contains information about the event (event), repository,
    commit SHA, reference, and the GitHub workflow details. A unique request ID
    (requestID) is generated for each request. Signatures:
-
-3. The payload is signed using both SHA-1 and SHA-256 HMAC signatures, using the
+1. The payload is signed using both SHA-1 and SHA-256 HMAC signatures, using the
    webhook URL as the secret key. Options:
-
-4. You can control the verbosity of the logs by setting the verbose input to
+1. You can control the verbosity of the logs by setting the verbose input to
    true. This will print detailed curl command logs. Setting the silent input to
    true will suppress output, but logs can still be reviewed in verbose mode.
    Response Handling:
-
-5. The response body from the webhook request is captured and outputted under
+1. The response body from the webhook request is captured and outputted under
    the response-body output. Security Ensure that sensitive information such as
    webhook_production and webhook_release URLs are stored securely in GitHub
    Secrets. Do not hardcode them in the workflow files.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ supports both SHA-1 and SHA-256 HMAC signatures for securing webhook requests.
 ## Inputs
 
 | Input                 | Description                            | Default   |
-|-----------------------|----------------------------------------|-----------|
+| --------------------- | -------------------------------------- | --------- |
 | `production_branch`\* | Your production branch.                | `main`    |
 | `release_branch`      | Your release branch.                   | `release` |
 | `webhook_production`  | Webhook URL for the production.        | N/A       |


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration and documentation improvements. The most important changes include modifying the linter workflow to trigger only on push events and improving the readability and structure of the README.md file.

### Workflow Configuration:

* [`.github/workflows/linter.yml`](diffhunk://#diff-ba16fc050e9c818b8125acc6d33b13f4c427ca91373d286af13d0fc92da90605L5-L6): Modified the linter workflow to trigger only on push events to the `main` branch, removing the trigger for pull request events.

### Documentation Improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R18): Improved the readability and structure of the inputs table by aligning the columns and simplifying descriptions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R85): Corrected the numbering and improved the readability of the webhook payload and options sections.